### PR TITLE
fix: fixed output path for build

### DIFF
--- a/@uportal/notification-banner/package.json
+++ b/@uportal/notification-banner/package.json
@@ -17,7 +17,7 @@
     "scripts": {
         "serve": "vue-cli-service serve",
         "prebuild": "babel node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js -o node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js",
-        "build": "vue-cli-service build --target wc --name notification-banner --dest build/static/js 'src/components/NotificationBanner.vue'",
+        "build": "vue-cli-service build --target wc --name notification-banner 'src/components/NotificationBanner.vue'",
         "lint": "vue-cli-service lint"
     },
     "dependencies": {

--- a/@uportal/notification-modal/package.json
+++ b/@uportal/notification-modal/package.json
@@ -16,7 +16,7 @@
     "source": "src/components/NotificationModal.vue",
     "scripts": {
         "serve": "vue-cli-service serve",
-        "build": "vue-cli-service build --target wc --name notification-modal --dest build/static/js 'src/components/NotificationModal.vue'",
+        "build": "vue-cli-service build --target wc --name notification-modal 'src/components/NotificationModal.vue'",
         "prebuild": "babel node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js -o node_modules/@vue/web-component-wrapper/dist/vue-wc-wrapper.js",
         "lint": "vue-cli-service lint"
     },


### PR DESCRIPTION
Removed explicitly set destination for component build. Resource-server expects the js to be in a dist/ folder which is default.