### PR TITLE
fix: added transform-commonjs babel plugin

### DIFF
--- a/@uportal/notification-modal/babel.config.js
+++ b/@uportal/notification-modal/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-    presets: ['@babel/preset-env'],
+    presets: [['@babel/preset-env', { modules: 'commonjs' }]],
     plugins: [['@babel/plugin-transform-runtime', { useESModules: true }]]
 };


### PR DESCRIPTION
Adds the '@babel/plugin-transform-modules-commonjs' plugin to fix exports error in notification-modal component.