### PR TITLE
fix(notification-banner): have babel output commonjs for webpack

### DIFF
--- a/@uportal/notification-banner/babel.config.js
+++ b/@uportal/notification-banner/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-    presets: ['@babel/preset-env'],
+    presets: [['@babel/preset-env', { modules: 'commonjs' }]],
     plugins: [['@babel/plugin-transform-runtime', { useESModules: true }]]
 };


### PR DESCRIPTION
Instruct Babel to process `commonjs` in such a way that Webpack will package it appropriately.